### PR TITLE
Create resource groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,10 +9,14 @@ locals {
       }
     ]
   ])
+
+  applications_map = {
+    for index, application in local.applications : index => application
+  }
 }
 
 resource "azurerm_resource_group" "main" {
-  for_each = { for index, application in local.applications : index => application }
+  for_each = applications_map
 
   name     = each.value.name
   location = each.value.location

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,11 @@
 locals {
   applications = flatten([
-    for application in var.applications : [
-      for environment in var.environments : {
-        name                 = "rg-${application}-${environment}"        
-        location             = environment == "prod" ? var.locations.primary : var.locations.secondary
-        work_force           = environment == "prod" ? "production" : "non-production"
-        has_developer_access = environment == "prod" ? "no" : "yes"
+    for application_name in var.application_names : [
+      for environment_name in var.environment_names : {
+        name                 = "rg-${application_name}-${environment_name}"        
+        location             = environment_name == "prod" ? var.locations.primary : var.locations.secondary
+        work_force           = environment_name == "prod" ? "production" : "non-production"
+        has_developer_access = environment_name == "prod" ? "no" : "yes"
       }
     ]
   ])

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,24 @@
+locals {
+  applications = flatten([
+    for application in var.applications : [
+      for environment in var.environments : {
+        name                 = "rg-${application}-${environment}"        
+        location             = environment == "prod" ? var.locations.primary : var.locations.secondary
+        work_force           = environment == "prod" ? "production" : "non-production"
+        has_developer_access = environment == "prod" ? "no" : "yes"
+      }
+    ]
+  ])
+}
+
+resource "azurerm_resource_group" "main" {
+  for_each = { for index, application in local.applications : index => application }
+
+  name     = each.value.name
+  location = each.value.location
+
+  tags = {
+    work_force           = each.value.work_force
+    has_developer_access = each.value.has_developer_access
+  }
+}

--- a/main.tftest.hcl
+++ b/main.tftest.hcl
@@ -4,8 +4,8 @@ run "ResourceGroupsCreatedProperly_GivenValidInput" {
     environment_names = ["dev", "prod"]
 
     locations = {
-      primary   = "North Europe"
-      secondary = "East US"
+      primary   = "northeurope"
+      secondary = "eastus"
     }
   }
 

--- a/main.tftest.hcl
+++ b/main.tftest.hcl
@@ -13,41 +13,41 @@ run "ResourceGroupsCreatedProperly_GivenValidInput" {
 
   assert {
     condition     = azurerm_resource_group.main[0].name == "rg-app1-dev"
-    error_message = "Invalid app1 resource group name."
+    error_message = "Invalid app1 dev resource group name."
   }
 
   assert {
     condition     = azurerm_resource_group.main[0].location == "eastus"
-    error_message = "Invalid app1 resource group location."
+    error_message = "Invalid app1 dev resource group location."
   }
 
   assert {
     condition     = azurerm_resource_group.main[1].name == "rg-app1-prod"
-    error_message = "Invalid app1 resource group name."
+    error_message = "Invalid app1 prod resource group name."
   }
 
   assert {
     condition     = azurerm_resource_group.main[1].location == "northeurope"
-    error_message = "Invalid app1 resource group location."
+    error_message = "Invalid app1 prod resource group location."
   }
 
   assert {
     condition     = azurerm_resource_group.main[2].name == "rg-app2-dev"
-    error_message = "Invalid app2 resource group name."
+    error_message = "Invalid app2 dev resource group name."
   }
 
   assert {
     condition     = azurerm_resource_group.main[2].location == "eastus"
-    error_message = "Invalid app2 resource group location."
+    error_message = "Invalid app2 dev resource group location."
   }
 
   assert {
     condition     = azurerm_resource_group.main[3].name == "rg-app2-prod"
-    error_message = "Invalid app2 resource group name."
+    error_message = "Invalid app2 prod resource group name."
   }
 
   assert {
     condition     = azurerm_resource_group.main[3].location == "northeurope"
-    error_message = "Invalid app2 resource group location."
+    error_message = "Invalid app2 prod resource group location."
   }
 }

--- a/main.tftest.hcl
+++ b/main.tftest.hcl
@@ -1,0 +1,53 @@
+run "ResourceGroupsCreatedProperly_GivenValidInput" {
+  variables {
+    application_names = ["app1", "app2"]
+    environment_names = ["dev", "prod"]
+
+    locations = {
+      primary   = "North Europe"
+      secondary = "East US"
+    }
+  }
+
+  command = plan
+
+  assert {
+    condition     = azurerm_resource_group.main[0].name == "rg-app1-dev"
+    error_message = "Invalid app1 resource group name."
+  }
+
+  assert {
+    condition     = azurerm_resource_group.main[0].location == "eastus"
+    error_message = "Invalid app1 resource group location."
+  }
+
+  assert {
+    condition     = azurerm_resource_group.main[1].name == "rg-app1-prod"
+    error_message = "Invalid app1 resource group name."
+  }
+
+  assert {
+    condition     = azurerm_resource_group.main[1].location == "northeurope"
+    error_message = "Invalid app1 resource group location."
+  }
+
+  assert {
+    condition     = azurerm_resource_group.main[2].name == "rg-app2-dev"
+    error_message = "Invalid app2 resource group name."
+  }
+
+  assert {
+    condition     = azurerm_resource_group.main[2].location == "eastus"
+    error_message = "Invalid app2 resource group location."
+  }
+
+  assert {
+    condition     = azurerm_resource_group.main[3].name == "rg-app2-prod"
+    error_message = "Invalid app2 resource group name."
+  }
+
+  assert {
+    condition     = azurerm_resource_group.main[3].location == "northeurope"
+    error_message = "Invalid app2 resource group location."
+  }
+}

--- a/main.tftest.hcl
+++ b/main.tftest.hcl
@@ -23,6 +23,16 @@ run "ResourceGroupsCreatedProperly_GivenValidInput" {
     error_message = "Invalid app1 dev resource group location."
   }
 
+  assert {
+    condition     = azurerm_resource_group.main[0].tags["work_force"] == "non-production"
+    error_message = "Invalid app1 dev resource group work_force tag."
+  }
+
+  assert {
+    condition     = azurerm_resource_group.main[0].tags["has_developer_access"] == "yes"
+    error_message = "Invalid app1 dev resource group has_developer_access tag."
+  }
+
   # App1 prod asserts
 
   assert {
@@ -33,6 +43,16 @@ run "ResourceGroupsCreatedProperly_GivenValidInput" {
   assert {
     condition     = azurerm_resource_group.main[1].location == "northeurope"
     error_message = "Invalid app1 prod resource group location."
+  }
+
+  assert {
+    condition     = azurerm_resource_group.main[1].tags["work_force"] == "production"
+    error_message = "Invalid app1 prod resource group work_force tag."
+  }
+
+  assert {
+    condition     = azurerm_resource_group.main[1].tags["has_developer_access"] == "no"
+    error_message = "Invalid app1 prod resource group has_developer_access tag."
   }
 
   # App2 dev asserts
@@ -47,6 +67,16 @@ run "ResourceGroupsCreatedProperly_GivenValidInput" {
     error_message = "Invalid app2 dev resource group location."
   }
 
+  assert {
+    condition     = azurerm_resource_group.main[2].tags["work_force"] == "non-production"
+    error_message = "Invalid app2 dev resource group work_force tag."
+  }
+
+  assert {
+    condition     = azurerm_resource_group.main[2].tags["has_developer_access"] == "yes"
+    error_message = "Invalid app2 dev resource group has_developer_access tag."
+  }
+
   # App2 prod asserts
 
   assert {
@@ -57,5 +87,15 @@ run "ResourceGroupsCreatedProperly_GivenValidInput" {
   assert {
     condition     = azurerm_resource_group.main[3].location == "northeurope"
     error_message = "Invalid app2 prod resource group location."
+  }
+
+  assert {
+    condition     = azurerm_resource_group.main[3].tags["work_force"] == "production"
+    error_message = "Invalid app2 prod resource group work_force tag."
+  }
+
+  assert {
+    condition     = azurerm_resource_group.main[3].tags["has_developer_access"] == "no"
+    error_message = "Invalid app2 prod resource group has_developer_access tag."
   }
 }

--- a/main.tftest.hcl
+++ b/main.tftest.hcl
@@ -11,6 +11,8 @@ run "ResourceGroupsCreatedProperly_GivenValidInput" {
 
   command = plan
 
+  # App1 dev asserts
+
   assert {
     condition     = azurerm_resource_group.main[0].name == "rg-app1-dev"
     error_message = "Invalid app1 dev resource group name."
@@ -20,6 +22,8 @@ run "ResourceGroupsCreatedProperly_GivenValidInput" {
     condition     = azurerm_resource_group.main[0].location == "eastus"
     error_message = "Invalid app1 dev resource group location."
   }
+
+  # App1 prod asserts
 
   assert {
     condition     = azurerm_resource_group.main[1].name == "rg-app1-prod"
@@ -31,6 +35,8 @@ run "ResourceGroupsCreatedProperly_GivenValidInput" {
     error_message = "Invalid app1 prod resource group location."
   }
 
+  # App2 dev asserts
+
   assert {
     condition     = azurerm_resource_group.main[2].name == "rg-app2-dev"
     error_message = "Invalid app2 dev resource group name."
@@ -40,6 +46,8 @@ run "ResourceGroupsCreatedProperly_GivenValidInput" {
     condition     = azurerm_resource_group.main[2].location == "eastus"
     error_message = "Invalid app2 dev resource group location."
   }
+
+  # App2 prod asserts
 
   assert {
     condition     = azurerm_resource_group.main[3].name == "rg-app2-prod"

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = "1.9.8"
+
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "4.7.0"
+    }
+  }
+
+  cloud {
+    organizations = "[HCP org name]"
+
+    workspaces {
+      name = "[HCP workspace name]"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "4.7.0"
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,11 @@
-variable "applications" {
+variable "application_names" {
   type = list(string)
+  description = "Names of the applications."
 }
 
-variable "environments" {
+variable "environment_names" {
   type = list(string)
+  description = "Names of the environments."
 }
 
 variable "locations" {
@@ -11,4 +13,5 @@ variable "locations" {
     primary   = string
     secondary = string
   })
+  description = "Primary and secondary locations."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,10 @@
 variable "application_names" {
-  type = list(string)
+  type        = list(string)
   description = "Names of the applications."
 }
 
 variable "environment_names" {
-  type = list(string)
+  type        = list(string)
   description = "Names of the environments."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,14 @@
+variable "applications" {
+  type = list(string)
+}
+
+variable "environments" {
+  type = list(string)
+}
+
+variable "locations" {
+  type = object({
+    primary   = string
+    secondary = string
+  })
+}


### PR DESCRIPTION
Create resource groups based on input variables.

Related to #2 

Coming from a traditional programming language background, I sometimes find terraform syntax difficult to understand. Today I am learning nested loops in terraform.

I want to create some resource groups in azure based on input variables. The user of this module can send three input variables in it. Application names, environment names and primary and secondary locations. This module will create resource groups for each application and environment. If the environment is prod then it creates the resource group in the primary location otherwise in secondary location.

@markti can you please review the code changes? I have also added a unit test so that you can be able to understand the expected behavior. 